### PR TITLE
allow skipping files in copy listener

### DIFF
--- a/cprf.js
+++ b/cprf.js
@@ -26,7 +26,7 @@ function copy (src, dest, done) {
   fs.lstat(src, function (err, stats) {
     if (err) return _error(err);
 
-    ee.emit('copy', stats, src, dest, _copy);
+    ee.emit('copy', stats, src, dest, _copy, done);
 
     if (!ee.listeners('copy').length) {
       return _copy(src, dest, null);

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,24 @@ test('transforming copy listener modifying destination filename', function (t) {
   });
 });
 
+test('skipping files in copy listener', function (t) {
+  var _dest = path.join(dest, 'skip');
+  cprf(src, _dest, function (e) {
+    t.error(e, 'should not error');
+    fs.readdir(_dest, function (err, files) {
+        if (err) return t.end(err);
+        t.deepEqual(files, ['dir_1_level', 'dir_2_levels', 'dir_3_levels']);
+        t.end();
+    });
+  }).on('copy', function (stats, src, dest, copy, skip) {
+    if (stats.isDirectory()) {
+      copy(src, dest, null);
+    } else {
+      skip();
+    }
+  });
+});
+
 test('teardown', function (t) {
   rimraf(dest, t.end);
 });


### PR DESCRIPTION
At the moment, if the copy listener is specified, it **must** call the `copy` callback for each file in order for the overall copy operation to complete.

This change passes an extra `skip` callback to the copy listener, which the listener can call instead of the `copy` callback. This allows you to filter which files you copy (e.g. filtering out `.DS_Store`/`Thumbs.db` etc).

I'm aware that this clutters the copy listener API a bit, so no worries if you don't think it should go into master. Thanks!
